### PR TITLE
Make preset more "vanilla"?

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,19 +6,6 @@ module.exports = (neutrino, options) => {
     eslint: {
       baseConfig: {
         extends: ['airbnb']
-      },
-      rules: {
-        // handled by babel rules
-        'new-cap': 'off',
-
-        // handled by babel rules
-        'object-curly-spacing': 'off',
-
-        // require a capital letter for constructors
-        'babel/new-cap': ['error', { newIsCap: true }],
-
-        // require padding inside curly braces
-        'babel/object-curly-spacing': ['error', 'always'],
       }
     }
   }, options));


### PR DESCRIPTION
Personally, I think having these rules makes this package too opinionated.
Since the package is called just `neutrino-preset-airbnb`, as a user of the preset I would not expect to find additional rules beyond the vanilla ones provided by airbnb.

What do you think?