### PR TITLE
Upgrade to Neutrino 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "7"
+  - "8"
   - "6.9"
-

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const merge = require('deepmerge');
-const eslint = require('neutrino-middleware-eslint');
+const eslint = require('@neutrinojs/eslint');
 
 module.exports = (neutrino, options = {}) => {
   neutrino.use(eslint, merge({

--- a/package.json
+++ b/package.json
@@ -27,17 +27,17 @@
     "deepmerge": "^1.5.2",
     "eslint": "^4.0.0",
     "eslint-config-airbnb": "^16.0.0",
-    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.0.0",
-    "eslint-plugin-react": "^7.4.0",
-    "neutrino-middleware-eslint": "^7.0.0"
+    "eslint-plugin-react": "^7.5.0",
+    "@neutrinojs/eslint": "^8.0.14"
   },
   "peerDependencies": {
-    "neutrino": "^7.0.0"
+    "neutrino": "^8.0.0"
   },
   "devDependencies": {
     "ava": "^0.19.1",
-    "neutrino": "^7.0.0",
+    "neutrino": "^8.0.0",
     "standard-version": "^4.0.0",
     "webpack": "^3.0.0"
   }


### PR DESCRIPTION
Updated dependency on Neutrino 8. Several packages was updated too. 

The major version should be updated to **5.0.0**, as it is a breaking change.