### PR TITLE
chore: update travis file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "7"
+  - "8"
   - "6.9"
 


### PR DESCRIPTION
Neutrino V8 version is not compatible with Node 7, so the CI is failing actually just for that in #6 .

> warning You are using Node "7.10.1" which is not supported and may encounter bugs or unexpected behavior. Yarn supports the following semver range: "^4.8.0 || ^5.7.0 || ^6.2.2 || >=8.0.0"
> [1/4] Resolving packages...
> [2/4] Fetching packages...
> error @neutrinojs/eslint@8.0.14: The engine "node" is incompatible with this module. Expected version "^6.9.0 || ^8 || >=9".

I updated the travis file to use Node 8 instead.